### PR TITLE
Make mybinder work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y python3-pip
 
 COPY . /usr/local/oommfc/
 WORKDIR /usr/local/oommfc
-RUN python3 -m pip install matplotlib<=2.2.3
+RUN python3 -m pip install "matplotlib<3.0.0"
 RUN python3 -m pip install oommfc
 
 # Commands to make Binder work.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# This Dockerfile is used for Binder only. Dockerfile for tests and
+# builds is in docker directory.
+
+FROM joommf/oommf
+
+USER root
+
+RUN apt-get update -y
+RUN apt-get install -y python3-pip
+
+COPY . /usr/local/oommfc/
+WORKDIR /usr/local/oommfc
+RUN python3 -m pip install matplotlib<3
+RUN python3 -m pip install oommfc
+
+# Commands to make Binder work.
+RUN python3 -m pip install --no-cache-dir notebook==5.*
+ENV NB_USER binderuser
+ENV NB_UID 1000
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+RUN chown -R ${NB_UID} /usr/local/oommfc
+USER ${NB_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y python3-pip
 
 COPY . /usr/local/oommfc/
 WORKDIR /usr/local/oommfc
-RUN python3 -m pip install matplotlib<3
+RUN python3 -m pip install matplotlib<=2.2.3
 RUN python3 -m pip install oommfc
 
 # Commands to make Binder work.

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - matplotlib<3.0.0
-  - joommf


### PR DESCRIPTION
Was complicated:
1. we need to install OOMMF
   - either via conda-forge 
   - or by using joommf/oommf Dockerfile

Conda-forge seemed easier but doesn't work on Ubuntu 18:04 linux yet.

Then used Docker.

2. Need to use matplotlib<3; because due to some matplotlib change in 3.0, the discretisedfield plots are broken

This MR provides the rigth Dockerfile.